### PR TITLE
Fix: fixing full path in description of policy, adding AvpPolicyDescription annotation

### DIFF
--- a/src/cedar-helpers.ts
+++ b/src/cedar-helpers.ts
@@ -1,6 +1,8 @@
 
 import * as cedar from '@cedar-policy/cedar-wasm/nodejs';
 
+export const POLICY_DESCRIPTION_ANNOTATION = '@AvpPolicyDescription';
+
 export function checkParseSchema(schemaStr: string) {
   const schemaParseResult = cedar.checkParseSchema(schemaStr);
   if (schemaParseResult.type === 'error') {
@@ -13,6 +15,17 @@ export function checkParsePolicy(policyStatement: string) {
   if (parsePolicyResult.type == 'error') {
     throw new Error(`Invalid policy statement: ${policyStatement}. Errors: ${parsePolicyResult.errors.join(', ')}`);
   }
+}
+
+/**
+ * Extracts the Description of the Policy searching for the 'AVPPolicyDescription' annotation on top of policy contents (before effect)
+ * @param policyStatement The policy statement in string format
+ * @returns Returns the description if found or null
+ */
+export function getPolicyDescription(policyStatement: string): string | null {
+  const regex = new RegExp(String.raw`^${POLICY_DESCRIPTION_ANNOTATION}\(("|')(.*)("|')(\))([\r\n|\r|\n| ]*)(permit|forbid)`);
+  let matches = policyStatement.match(regex);
+  return (matches) ? matches[2] : null;
 }
 
 export function checkParseTemplate(templateStatement: string) {

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -1,8 +1,9 @@
 import * as fs from 'fs';
+import * as path from 'path';
 import { CfnPolicy } from 'aws-cdk-lib/aws-verifiedpermissions';
 import { IResource, Resource } from 'aws-cdk-lib/core';
 import { Construct } from 'constructs';
-import { checkParsePolicy } from './cedar-helpers';
+import { checkParsePolicy, getPolicyDescription } from './cedar-helpers';
 import { IPolicyStore } from './policy-store';
 import { IPolicyTemplate } from './policy-template';
 
@@ -194,11 +195,12 @@ export class Policy extends PolicyBase {
   ): Policy {
     const policyFileContents = fs.readFileSync(props.path).toString();
     checkParsePolicy(policyFileContents);
+    let policyDescription = props.description || getPolicyDescription(policyFileContents) || path.basename(props.path) + '- Created by CDK';
     return new Policy(scope, id, {
       definition: {
         static: {
           statement: policyFileContents,
-          description: props.description || `${props.path} - Created by CDK`,
+          description: policyDescription,
         },
       },
       policyStore: props.policyStore,

--- a/test/cedar-helpers.test.ts
+++ b/test/cedar-helpers.test.ts
@@ -1,4 +1,4 @@
-import { cleanUpApiNameForNamespace } from '../src/cedar-helpers';
+import { cleanUpApiNameForNamespace, getPolicyDescription, POLICY_DESCRIPTION_ANNOTATION } from '../src/cedar-helpers';
 
 describe('testing edge cases in cedar helpers', () => {
   test('cleanUpApiNameForNamespace tests', () => {
@@ -6,5 +6,68 @@ describe('testing edge cases in cedar helpers', () => {
     expect(cleanUpApiNameForNamespace('bad-name')).toBe('badname');
     expect(cleanUpApiNameForNamespace('---')).toBe('ImportedApi');
     expect(cleanUpApiNameForNamespace('1234backend')).toBe('Api1234backend');
+  });
+});
+
+describe('testing get description of policy', () => {
+  test('get description of policy with non-compliant string', () => {
+    let policy = 'test test';
+    expect(getPolicyDescription(policy)).toBeNull();
+  });
+
+  test('get description of policy with compliant string and permit effect', () => {
+    let description = '4124 .,%|/! ^ I am? a description @@@ 1233421';
+    let policy = `${POLICY_DESCRIPTION_ANNOTATION}("${description}")permit`;
+    expect(getPolicyDescription(policy)).toBe(description);
+  });
+
+  test('get description of policy with compliant string and space between permit effect', () => {
+    let description = '4124 .,%|/! ^ I am? a description @@@ 1233421';
+    let policy = `${POLICY_DESCRIPTION_ANNOTATION}("${description}") permit`;
+    expect(getPolicyDescription(policy)).toBe(description);
+  });
+
+  test('get description of policy with compliant multiline string and permit effect', () => {
+    let description = '4124 .,%|/! ^ I am? a description @@@ 1233421';
+    let policy = `${POLICY_DESCRIPTION_ANNOTATION}("${description}")
+    permit (
+      principal,
+      action in [MyFirstApp::Action::"Read"],
+      resource
+    )
+    when { true };
+    `;
+    expect(getPolicyDescription(policy)).toBe(description);
+  });
+
+  test('get description of policy with compliant string and forbid effect', () => {
+    let description = '4124 .,%|/! ^ I am? a description @@@ 1233421';
+    let policy = `${POLICY_DESCRIPTION_ANNOTATION}("${description}")forbid`;
+    expect(getPolicyDescription(policy)).toBe(description);
+  });
+
+  test('get description of policy with compliant string and space between forbid effect', () => {
+    let description = '4124 .,%|/! ^ I am? a description @@@ 1233421';
+    let policy = `${POLICY_DESCRIPTION_ANNOTATION}("${description}") forbid`;
+    expect(getPolicyDescription(policy)).toBe(description);
+  });
+
+  test('get description of policy with compliant multiline string and forbid effect', () => {
+    let description = '4124 .,%|/! ^ I am? a description @@@ 1233421';
+    let policy = `${POLICY_DESCRIPTION_ANNOTATION}("${description}")
+    forbid (
+      principal,
+      action in [MyFirstApp::Action::"Read"],
+      resource
+    )
+    when { true };
+    `;
+    expect(getPolicyDescription(policy)).toBe(description);
+  });
+
+  test('get description of policy with compliant string and no effect', () => {
+    let description = '4124 .,%|/! ^ I am? a description @@@ 1233421';
+    let policy = `${POLICY_DESCRIPTION_ANNOTATION}("${description}")`;
+    expect(getPolicyDescription(policy)).toBe(null);
   });
 });

--- a/test/policy-store.test.ts
+++ b/test/policy-store.test.ts
@@ -546,10 +546,11 @@ describe('Policy store with policies from a path', () => {
     );
 
     const policyDefns = Template.fromStack(stack).findResources('AWS::VerifiedPermissions::Policy');
-    expect(Object.keys(policyDefns)).toHaveLength(2);
+    expect(Object.keys(policyDefns)).toHaveLength(3);
     const statements = Object.values(policyDefns).map(cfnPolicy => cfnPolicy.Properties.Definition.Static.Statement);
     expect(statements).toStrictEqual([
       fs.readFileSync('test/test-policies/all-valid/policy1.cedar', 'utf-8'),
+      fs.readFileSync('test/test-policies/all-valid/policy1_with_desc_annotation.cedar', 'utf-8'),
       fs.readFileSync('test/test-policies/all-valid/policy2.cedar', 'utf-8'),
     ]);
   });

--- a/test/test-policies/all-valid/policy1_with_desc_annotation.cedar
+++ b/test/test-policies/all-valid/policy1_with_desc_annotation.cedar
@@ -1,0 +1,2 @@
+@AvpPolicyDescription("I am a description")
+permit(principal, action, resource);


### PR DESCRIPTION
- Fixing file full path in description of the policy, now we keep the basepath of the file
- Added management of a new annotation AvpPolicyDescription which can be added on top of the policy in order to provide a description for it. We're following the rules here: https://docs.cedarpolicy.com/policies/syntax-policy.html
- Description priority is the follow:
1) If description is present in the properties --> we keep this
2) If not, we try to search the annotation above 
3) If the annotation is not present we keep the basePath of file

Fixes #196 