### PR TITLE
feat: generate schema from cloudformation template

### DIFF
--- a/API.md
+++ b/API.md
@@ -966,6 +966,7 @@ Permits an IAM principal all write & read operations on the policy store: Create
 | <code><a href="#@cdklabs/cdk-verified-permissions.PolicyStore.fromPolicyStoreArn">fromPolicyStoreArn</a></code> | Create a PolicyStore construct that represents an external PolicyStore via policy store arn. |
 | <code><a href="#@cdklabs/cdk-verified-permissions.PolicyStore.fromPolicyStoreAttributes">fromPolicyStoreAttributes</a></code> | Creates a PolicyStore construct that represents an external Policy Store. |
 | <code><a href="#@cdklabs/cdk-verified-permissions.PolicyStore.fromPolicyStoreId">fromPolicyStoreId</a></code> | Create a PolicyStore construct that represents an external policy store via policy store id. |
+| <code><a href="#@cdklabs/cdk-verified-permissions.PolicyStore.schemaFromCfTemplate">schemaFromCfTemplate</a></code> | This method generates a schema based on a JSON CloudFormation template containing exactly one RestApi. |
 | <code><a href="#@cdklabs/cdk-verified-permissions.PolicyStore.schemaFromOpenApiSpec">schemaFromOpenApiSpec</a></code> | This method generates a schema based on an swagger file. |
 
 ---
@@ -1119,6 +1120,36 @@ The construct's name.
 - *Type:* string
 
 The PolicyStore's id.
+
+---
+
+##### `schemaFromCfTemplate` <a name="schemaFromCfTemplate" id="@cdklabs/cdk-verified-permissions.PolicyStore.schemaFromCfTemplate"></a>
+
+```typescript
+import { PolicyStore } from '@cdklabs/cdk-verified-permissions'
+
+PolicyStore.schemaFromCfTemplate(cfTemplateFilePath: string, groupEntityTypeName?: string)
+```
+
+This method generates a schema based on a JSON CloudFormation template containing exactly one RestApi.
+
+It makes the same assumptions and decisions made in the Amazon Verified Permissions console.
+
+###### `cfTemplateFilePath`<sup>Required</sup> <a name="cfTemplateFilePath" id="@cdklabs/cdk-verified-permissions.PolicyStore.schemaFromCfTemplate.parameter.cfTemplateFilePath"></a>
+
+- *Type:* string
+
+absolute path to a CloudFormation template file in the local directory structure, in json format.
+
+---
+
+###### `groupEntityTypeName`<sup>Optional</sup> <a name="groupEntityTypeName" id="@cdklabs/cdk-verified-permissions.PolicyStore.schemaFromCfTemplate.parameter.groupEntityTypeName"></a>
+
+- *Type:* string
+
+optional parameter to specify the group entity type name.
+
+If passed, the schema's User type will have a parent of this type.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -63,15 +63,37 @@ const policyStore = new PolicyStore(scope, "PolicyStore", {
 
 If you want to have type safety when defining a schema, you can accomplish this **<ins>only</ins>** in typescript. Simply use the `Schema` type exported by the `@cedar-policy/cedar-wasm`.
 
-You can also generate a simple schema from a swagger file using the static function `schemaFromOpenApiSpec` in the PolicyStore construct. This functionality replicates what you can find in the AWS Verified Permissions console.
+You can also generate simple schemas using the static functions `schemaFromOpenApiSpec` or `schemaFromCfTemplate` in the PolicyStore construct. This functionality replicates what you can find in the AWS Verified Permissions console.
+
+Generate a schema from an OpenAPI spec:
 
 ```ts
 const validationSettingsStrict = {
   mode: ValidationSettingsMode.STRICT,
 };
 const cedarJsonSchema = PolicyStore.schemaFromOpenApiSpec(
-  'path/to/swaggerfile.json',
-  'UserGroup',
+  "path/to/swaggerfile.json",
+  "UserGroup"
+);
+const cedarSchema = {
+  cedarJson: JSON.stringify(cedarJsonSchema),
+};
+const policyStore = new PolicyStore(scope, "PolicyStore", {
+  schema: cedarSchema,
+  validationSettings: validationSettingsStrict,
+  description: "Policy store with schema generated from API Gateway",
+});
+```
+
+Generate a schema from a CloudFormation template:
+
+```ts
+const validationSettingsStrict = {
+  mode: ValidationSettingsMode.STRICT,
+};
+const cedarJsonSchema = PolicyStore.schemaFromCfTemplate(
+  "path/to/cftemplate.json",
+  "UserGroup"
 );
 const cedarSchema = {
   cedarJson: JSON.stringify(cedarJsonSchema),

--- a/test/podcastappcloudformation.json
+++ b/test/podcastappcloudformation.json
@@ -1,0 +1,118 @@
+{
+  "Resources": {
+    "PodcastAppApi262252D3": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Name": "PodcastApp"
+      }
+    },
+    "PodcastAppApiartistsGET932A4BE6": {
+      "Type": "AWS::ApiGateway::Method",
+      "Properties": {
+        "HttpMethod": "GET",
+        "ResourceId": {
+          "Ref": "PodcastAppApiartistsE74E9D28"
+        }
+      }
+    },
+    "PodcastAppApiartistsPOSTE5F58123": {
+      "Type": "AWS::ApiGateway::Method",
+      "Properties": {
+        "HttpMethod": "POST",
+        "ResourceId": {
+          "Ref": "PodcastAppApiartistsE74E9D28"
+        }
+      }
+    },
+    "PodcastAppApiartistsDELETED8ECABA1": {
+      "Type": "AWS::ApiGateway::Method",
+      "Properties": {
+        "HttpMethod": "DELETE",
+        "ResourceId": {
+          "Ref": "PodcastAppApiartistsE74E9D28"
+        }
+      }
+    },
+    "PodcastAppApiartistsartistId67271C01": {
+      "Type": "AWS::ApiGateway::Resource",
+      "Properties": {
+        "ParentId": {
+          "Ref": "PodcastAppApiartistsE74E9D28"
+        },
+        "PathPart": "{artistId}"
+      }
+    },
+    "PodcastAppApiartistsartistIdDELETE33FE0AE3": {
+      "Type": "AWS::ApiGateway::Method",
+      "Properties": {
+        "HttpMethod": "DELETE",
+        "ResourceId": {
+          "Ref": "PodcastAppApiartistsartistId67271C01"
+        }
+      }
+    },
+    "PodcastAppApiartistsartistIdPATCH59F1CFD1": {
+      "Type": "AWS::ApiGateway::Method",
+      "Properties": {
+        "HttpMethod": "PATCH",
+        "ResourceId": {
+          "Ref": "PodcastAppApiartistsartistId67271C01"
+        }
+      }
+    },
+    "PodcastAppApipodcasts497B898A": {
+      "Type": "AWS::ApiGateway::Resource",
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": ["PodcastAppApi262252D3", "RootResourceId"]
+        },
+        "PathPart": "podcasts"
+      }
+    },
+    "PodcastAppApipodcastsGET85451B06": {
+      "Type": "AWS::ApiGateway::Method",
+      "Properties": {
+        "HttpMethod": "GET",
+        "ResourceId": {
+          "Ref": "PodcastAppApipodcasts497B898A"
+        }
+      }
+    },
+    "PodcastAppApipodcastsPOSTFC659675": {
+      "Type": "AWS::ApiGateway::Method",
+      "Properties": {
+        "HttpMethod": "POST",
+        "ResourceId": {
+          "Ref": "PodcastAppApipodcasts497B898A"
+        }
+      }
+    },
+    "PodcastAppApipodcastsDELETE86D19CD6": {
+      "Type": "AWS::ApiGateway::Method",
+      "Properties": {
+        "HttpMethod": "DELETE",
+        "ResourceId": {
+          "Ref": "PodcastAppApipodcasts497B898A"
+        }
+      }
+    },
+    "PodcastAppApipodcastspodcastId41A31CCC": {
+      "Type": "AWS::ApiGateway::Resource",
+      "Properties": {
+        "ParentId": {
+          "Ref": "PodcastAppApipodcasts497B898A"
+        },
+        "PathPart": "{podcastId}"
+      }
+    },
+    "PodcastAppApipodcastspodcastIdANY3158475C": {
+      "Type": "AWS::ApiGateway::Method",
+      "Properties": {
+        "HttpMethod": "ANY",
+        "ResourceId": {
+          "Ref": "PodcastAppApipodcastspodcastId41A31CCC"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #220 

This feature allows users to generate a schema from a CloudFormation template containing a RestAPI API Gateway resource. This is useful for allowing users to generate a schema without having to deploy their API and then export an OpenAPI spec - they can just use their CloudFormation template directly.