### PR TITLE
feat: generate schema from RestApi construct

### DIFF
--- a/API.md
+++ b/API.md
@@ -967,6 +967,7 @@ Permits an IAM principal all write & read operations on the policy store: Create
 | <code><a href="#@cdklabs/cdk-verified-permissions.PolicyStore.fromPolicyStoreAttributes">fromPolicyStoreAttributes</a></code> | Creates a PolicyStore construct that represents an external Policy Store. |
 | <code><a href="#@cdklabs/cdk-verified-permissions.PolicyStore.fromPolicyStoreId">fromPolicyStoreId</a></code> | Create a PolicyStore construct that represents an external policy store via policy store id. |
 | <code><a href="#@cdklabs/cdk-verified-permissions.PolicyStore.schemaFromOpenApiSpec">schemaFromOpenApiSpec</a></code> | This method generates a schema based on an swagger file. |
+| <code><a href="#@cdklabs/cdk-verified-permissions.PolicyStore.schemaFromRestApi">schemaFromRestApi</a></code> | This method generates a schema based on an AWS CDK RestApi construct. |
 
 ---
 
@@ -1150,6 +1151,37 @@ absolute path to a swagger file in the local directory structure, in json format
 - *Type:* string
 
 optional parameter to specify the group entity type name.
+
+If passed, the schema's User type will have a parent of this type.
+
+---
+
+##### `schemaFromRestApi` <a name="schemaFromRestApi" id="@cdklabs/cdk-verified-permissions.PolicyStore.schemaFromRestApi"></a>
+
+```typescript
+import { PolicyStore } from '@cdklabs/cdk-verified-permissions'
+
+PolicyStore.schemaFromRestApi(restApi: RestApi, groupEntityTypeName?: string)
+```
+
+This method generates a schema based on an AWS CDK RestApi construct.
+
+It makes the same assumptions
+and decisions made in the Amazon Verified Permissions console.
+
+###### `restApi`<sup>Required</sup> <a name="restApi" id="@cdklabs/cdk-verified-permissions.PolicyStore.schemaFromRestApi.parameter.restApi"></a>
+
+- *Type:* aws-cdk-lib.aws_apigateway.RestApi
+
+The RestApi construct instance from which to generate the schema.
+
+---
+
+###### `groupEntityTypeName`<sup>Optional</sup> <a name="groupEntityTypeName" id="@cdklabs/cdk-verified-permissions.PolicyStore.schemaFromRestApi.parameter.groupEntityTypeName"></a>
+
+- *Type:* string
+
+Specifies a group entity type name.
 
 If passed, the schema's User type will have a parent of this type.
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ const policyStore = new PolicyStore(scope, "PolicyStore", {
 
 If you want to have type safety when defining a schema, you can accomplish this **<ins>only</ins>** in typescript. Simply use the `Schema` type exported by the `@cedar-policy/cedar-wasm`.
 
-You can also generate a simple schema from a swagger file using the static function `schemaFromOpenApiSpec` in the PolicyStore construct. This functionality replicates what you can find in the AWS Verified Permissions console.
+You can also generate simple schemas using the static functions `schemaFromOpenApiSpec` or `schemaFromRestApi` in the PolicyStore construct. This functionality replicates what you can find in the AWS Verified Permissions console.
+
+Generate a schema from an OpenAPI spec:
 
 ```ts
 const validationSettingsStrict = {
@@ -80,6 +82,26 @@ const policyStore = new PolicyStore(scope, "PolicyStore", {
   schema: cedarSchema,
   validationSettings: validationSettingsStrict,
   description: "Policy store with schema generated from API Gateway",
+});
+```
+
+Generate a schema from a RestApi construct:
+
+```ts
+const validationSettingsStrict = {
+  mode: ValidationSettingsMode.STRICT,
+};
+const cedarJsonSchema = PolicyStore.schemaFromRestApi(
+  new RestApi(scope, "RestApi"),
+  "UserGroup",
+);
+const cedarSchema = {
+  cedarJson: JSON.stringify(cedarJsonSchema),
+};
+const policyStore = new PolicyStore(scope, "PolicyStore", {
+  schema: cedarSchema,
+  validationSettings: validationSettingsStrict,
+  description: "Policy store with schema generated from RestApi construct",
 });
 ```
 

--- a/rosetta/default.ts-fixture
+++ b/rosetta/default.ts-fixture
@@ -1,6 +1,7 @@
 // Fixture with packages imported, but nothing else
 import { IdentitySource, Policy, PolicyType, PolicyTemplate, AddPolicyOptions, PolicyStore, ValidationSettingsMode } from '@cdklabs/cdk-verified-permissions';
 import { UserPool } from 'aws-cdk-lib/aws-cognito';
+import { RestApi } from 'aws-cdk-lib/aws-apigateway';
 import { Stack } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 


### PR DESCRIPTION
Fixes #220 

Adds `PolicyStore.schemaFromRestApi()`, a method for generating AVP permissions schemas directly from the `RestApi` construct. This alternative allows for easier schema synchronization/generation when API changes occur, complementing the existing PolicyStore.schemaFromOpenApiSpec() that requires a Swagger JSON file.